### PR TITLE
Add Tracker configuration

### DIFF
--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -34,7 +34,6 @@ func NewKafkaTracker(
 	t = &KafkaTracker{}
 	t.Metadata = metadata
 
-	// TODO (Aleksandr Dorofeev): Add metrics registry to arguments
 	t.metrics.registry = metrics.DefaultRegistry
 
 	// fast producer

--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -12,7 +12,6 @@ import (
 type KafkaTracker struct {
 	BaseTracker
 	metrics struct {
-		// TODO (Aleksandr Dorofeev): Provide registry to Sarama
 		fastErrorRate metrics.Meter
 		safeErrorRate metrics.Meter
 	}

--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -51,7 +51,7 @@ func NewKafkaTracker(
 	config.ChannelBufferSize = 131072
 
 	t.metrics.fastErrorRate = metrics.GetOrRegisterMeter(
-		"tracker,type=fast send_error_rate",
+		"tracker,type=fast kafka_send_error_rate",
 		nil)
 
 	t.kafka.fast, err = sarama.NewAsyncProducer(brokers, config)
@@ -88,7 +88,7 @@ func NewKafkaTracker(
 		return nil, err
 	}
 	t.metrics.safeErrorRate = metrics.GetOrRegisterMeter(
-		"tracker,type=safe send_error_rate",
+		"tracker,type=safe kafka_send_error_rate",
 		nil)
 
 	return t, nil

--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -60,9 +60,9 @@ func NewKafkaTracker(
 	go func() {
 		for fastErr := range t.kafka.fast.Errors() {
 			t.metrics.fastErrorRate.Mark(1)
-			_ = log.WithFields(cue.Fields{
+			log.WithFields(cue.Fields{
 				"topic": fastErr.Msg.Topic,
-			}).Error(fastErr.Err, "send fast message failed")
+			}).Warnf("send fast message failed", fastErr.Err)
 		}
 	}()
 

--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -50,7 +50,7 @@ func NewKafkaTracker(
 	config.ChannelBufferSize = 131072
 
 	t.metrics.fastErrorRate = metrics.GetOrRegisterMeter(
-		"tracker,type=fast kafka_send_error_rate",
+		"tracker,type=fast kafka_produce_error_rate",
 		nil)
 
 	t.kafka.fast, err = sarama.NewAsyncProducer(brokers, config)
@@ -87,7 +87,7 @@ func NewKafkaTracker(
 		return nil, err
 	}
 	t.metrics.safeErrorRate = metrics.GetOrRegisterMeter(
-		"tracker,type=safe kafka_send_error_rate",
+		"tracker,type=safe kafka_produce_error_rate",
 		nil)
 
 	return t, nil

--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -51,7 +51,7 @@ func NewKafkaTracker(
 	config.ChannelBufferSize = 131072
 
 	t.metrics.fastErrorRate = metrics.GetOrRegisterMeter(
-		"tracker,service="+",type=fast send_error_rate",
+		"tracker,type=fast send_error_rate",
 		nil)
 
 	t.kafka.fast, err = sarama.NewAsyncProducer(brokers, config)
@@ -88,7 +88,7 @@ func NewKafkaTracker(
 		return nil, err
 	}
 	t.metrics.safeErrorRate = metrics.GetOrRegisterMeter(
-		"tracker,service="+",type=safe send_error_rate",
+		"tracker,type=safe send_error_rate",
 		nil)
 
 	return t, nil

--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -63,7 +63,7 @@ func NewKafkaTracker(
 			t.metrics.fastErrorRate.Mark(1)
 			_ = log.WithFields(cue.Fields{
 				"topic": fastErr.Msg.Topic,
-			}).Errorf(fastErr.Err, "fast message failed: %v", fastErr.Err)
+			}).Error(fastErr.Err, "send fast message failed")
 		}
 	}()
 


### PR DESCRIPTION
[trello](https://trello.com/c/VLJFX24R)

Added ability to provide configuration to KafkaTracker. Compatibility with the old API is preserved. 