### PR TITLE
Add new event test

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/remerge/go-timestr"
@@ -38,4 +39,28 @@ func (suite *EventTestSuite) TestEventMetadata() {
 	assert.Equal(suite.T(), eb.Cluster, "t1")
 	assert.Equal(suite.T(), eb.Host, "testhost")
 	assert.Equal(suite.T(), eb.Release, "123abc")
+}
+
+type testEvent struct {
+	EventBase
+	MyField string
+}
+
+func (suite *EventTestSuite) TestEventSerialize() {
+	m := &EventMetadata{
+		Service:     "test",
+		Environment: "testing",
+		Cluster:     "t1",
+		Host:        "testhost",
+		Release:     "123abc",
+	}
+
+	event := &testEvent{
+		MyField: "foo",
+	}
+	event.SetMetadata(m)
+
+	bytes, err := event.MarshalToJson()
+	assert.Nil(suite.T(), err)
+	fmt.Println(string(bytes))
 }

--- a/event_test.go
+++ b/event_test.go
@@ -60,7 +60,7 @@ func (suite *EventTestSuite) TestEventSerialize() {
 	}
 	event.SetMetadata(m)
 
-	bytes, err := event.MarshalToJson()
+	bytes, err := event.MarshalJSON()
 	assert.Nil(suite.T(), err)
 	fmt.Println(string(bytes))
 }


### PR DESCRIPTION
Hi. I am now debugging the go-tracker, and I found out that I am confused with how it is done now. 
Basically, the following test (see PR) fails with stack overflow because of 
```
func (eb *EventBase) MarshalJSON() ([]byte, error) {
	return json.Marshal(Event(eb))
}
```
So, my questions are:
* Should it work?
* What was the intent to make the MarshalJSON part of Event? Each Event MUST implement custom marshalling?
