### PR TITLE
Iteration in mock tracker + fix bug + add some tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.1'
 
 services:
   zookeeper:

--- a/mock_tracker.go
+++ b/mock_tracker.go
@@ -22,7 +22,7 @@ func NewMockTracker(metadata *EventMetadata) *MockTracker {
 func (t *MockTracker) Next(topic string) ([]byte, []byte) {
 	key := t.GetKey(topic, t.idxPosition)
 	value := t.Get(topic, t.idxPosition)
-	if key != nil && value != nil {
+	if key != nil || value != nil {
 		t.idxPosition++
 	}
 	return key, value
@@ -35,7 +35,7 @@ func (t *MockTracker) Get(topic string, idx int) []byte {
 	}
 
 	msgs := t.Messages[topic]
-	if msgs == nil || len(msgs) < idx {
+	if msgs == nil || len(msgs) <= idx {
 		return nil
 	}
 
@@ -49,7 +49,7 @@ func (t *MockTracker) GetKey(topic string, idx int) []byte {
 	}
 
 	msgs := t.ids[topic]
-	if msgs == nil || len(msgs) < idx {
+	if msgs == nil || len(msgs) <= idx {
 		return nil
 	}
 

--- a/mock_tracker.go
+++ b/mock_tracker.go
@@ -17,11 +17,8 @@ type MockTopicIterator struct {
 func (i *MockTopicIterator) Next() ([]byte, []byte, bool) {
 	key := i.tracker.GetKey(i.topic, i.idxPosition)
 	value := i.tracker.Get(i.topic, i.idxPosition)
-	if len(i.tracker.Messages[i.topic]) > i.idxPosition+1 {
-		i.idxPosition++
-		return key, value, true
-	}
-	return nil, nil, false
+	i.idxPosition++
+	return key, value, len(i.tracker.Messages[i.topic]) > i.idxPosition
 }
 
 var _ Tracker = (*MockTracker)(nil)

--- a/mock_tracker.go
+++ b/mock_tracker.go
@@ -3,8 +3,9 @@ package tracker
 // MockTracker is a tracker with in-memory storage used for testing.
 type MockTracker struct {
 	BaseTracker
-	Messages map[string][][]byte
-	ids      map[string][][]byte
+	Messages    map[string][][]byte
+	ids         map[string][][]byte
+	idxPosition int
 }
 
 var _ Tracker = (*MockTracker)(nil)
@@ -16,6 +17,15 @@ func NewMockTracker(metadata *EventMetadata) *MockTracker {
 	t.Messages = make(map[string][][]byte)
 	t.ids = make(map[string][][]byte)
 	return t
+}
+
+func (t *MockTracker) Next(topic string) ([]byte, []byte) {
+	key := t.GetKey(topic, t.idxPosition)
+	value := t.Get(topic, t.idxPosition)
+	if key != nil && value != nil {
+		t.idxPosition++
+	}
+	return key, value
 }
 
 // Get a message from the mock broker.

--- a/mock_tracker_test.go
+++ b/mock_tracker_test.go
@@ -6,21 +6,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func trackerWithSampleData(topic string, t *testing.T) *MockTracker {
-	metadata := EventMetadata{}
-	subject := NewMockTracker(&metadata)
+func TestMockTrackerBasic(t *testing.T) {
+	topic := "topic"
+	subject := NewMockTracker(&EventMetadata{})
 	err := subject.FastMessage(topic, []byte("message1"))
 	require.Nil(t, err)
 	err = subject.FastMessage(topic, []byte("message2"))
 	require.Nil(t, err)
 	err = subject.FastMessageWithKey(topic, []byte("message3"), []byte("key3"))
 	require.Nil(t, err)
-	return subject
-}
-
-func TestMockTrackerBasic(t *testing.T) {
-	topic := "topic"
-	subject := trackerWithSampleData(topic, t)
 
 	value := subject.Get(topic, 0)
 	require.Equal(t, "message1", string(value))
@@ -34,20 +28,33 @@ func TestMockTrackerBasic(t *testing.T) {
 
 func TestMockTrackerTopicIteration(t *testing.T) {
 	topic := "topic"
-	subject := trackerWithSampleData(topic, t)
+	subject := NewMockTracker(&EventMetadata{})
+	err := subject.FastMessage(topic, []byte("message1"))
+	require.Nil(t, err)
+	err = subject.FastMessage(topic, []byte("message2"))
+	require.Nil(t, err)
+	err = subject.FastMessageWithKey(topic, []byte("message3"), []byte("key3"))
+	require.Nil(t, err)
 	it := subject.Iterate(topic)
 	// Check iteration
 	key, value, canContinue := it.Next()
 	require.Nil(t, key)
 	require.Equal(t, "message1", string(value))
 	require.True(t, canContinue)
+
 	key, value, canContinue = it.Next()
 	require.Nil(t, key)
 	require.Equal(t, "message2", string(value))
 	require.True(t, canContinue)
+
 	key, value, canContinue = it.Next()
 	require.Equal(t, "key3", string(key))
 	require.Equal(t, "message3", string(value))
+	require.False(t, canContinue)
+
+	key, value, canContinue = it.Next()
+	require.Nil(t, key)
+	require.Nil(t, value)
 	require.False(t, canContinue)
 }
 

--- a/mock_tracker_test.go
+++ b/mock_tracker_test.go
@@ -48,10 +48,6 @@ func TestMockTrackerTopicIteration(t *testing.T) {
 	key, value, canContinue = it.Next()
 	require.Equal(t, string(key), "key3")
 	require.Equal(t, string(value), "message3")
-	require.True(t, canContinue)
-	key, value, canContinue = it.Next()
-	require.Nil(t, key)
-	require.Nil(t, value)
 	require.False(t, canContinue)
 }
 

--- a/mock_tracker_test.go
+++ b/mock_tracker_test.go
@@ -1,0 +1,42 @@
+package tracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockTrackerBasic(t *testing.T) {
+	metadata := EventMetadata{}
+	topic := "topic"
+	subject := NewMockTracker(&metadata)
+	err := subject.FastMessage(topic, []byte("message1"))
+	require.Nil(t, err)
+	err = subject.FastMessage(topic, []byte("message2"))
+	require.Nil(t, err)
+	err = subject.FastMessageWithKey(topic, []byte("message3"), []byte("key3"))
+	require.Nil(t, err)
+
+	value := subject.Get(topic, 0)
+	require.Equal(t, string(value), "message1")
+	value = subject.Get(topic, 1)
+	require.Equal(t, string(value), "message2")
+	value = subject.Get(topic, 2)
+	require.Equal(t, string(value), "message3")
+	value = subject.Get(topic, 3)
+	require.Nil(t, value)
+
+	// Check iteration
+	key, value := subject.Next(topic)
+	require.Nil(t, key)
+	require.Equal(t, string(value), "message1")
+	key, value = subject.Next(topic)
+	require.Nil(t, key)
+	require.Equal(t, string(value), "message2")
+	key, value = subject.Next(topic)
+	require.Equal(t, string(key), "key3")
+	require.Equal(t, string(value), "message3")
+	key, value = subject.Next(topic)
+	require.Nil(t, key)
+	require.Nil(t, value)
+}

--- a/mock_tracker_test.go
+++ b/mock_tracker_test.go
@@ -23,11 +23,11 @@ func TestMockTrackerBasic(t *testing.T) {
 	subject := trackerWithSampleData(topic, t)
 
 	value := subject.Get(topic, 0)
-	require.Equal(t, string(value), "message1")
+	require.Equal(t, "message1", string(value))
 	value = subject.Get(topic, 1)
-	require.Equal(t, string(value), "message2")
+	require.Equal(t, "message2", string(value))
 	value = subject.Get(topic, 2)
-	require.Equal(t, string(value), "message3")
+	require.Equal(t, "message3", string(value))
 	value = subject.Get(topic, 3)
 	require.Nil(t, value)
 }
@@ -39,15 +39,15 @@ func TestMockTrackerTopicIteration(t *testing.T) {
 	// Check iteration
 	key, value, canContinue := it.Next()
 	require.Nil(t, key)
-	require.Equal(t, string(value), "message1")
+	require.Equal(t, "message1", string(value))
 	require.True(t, canContinue)
 	key, value, canContinue = it.Next()
 	require.Nil(t, key)
-	require.Equal(t, string(value), "message2")
+	require.Equal(t, "message2", string(value))
 	require.True(t, canContinue)
 	key, value, canContinue = it.Next()
-	require.Equal(t, string(key), "key3")
-	require.Equal(t, string(value), "message3")
+	require.Equal(t, "key3", string(key))
+	require.Equal(t, "message3", string(value))
 	require.False(t, canContinue)
 }
 


### PR DESCRIPTION
Right now the usage of mock tracker is not very user friendly. One needs to give the offset for the topic.
```
Get(topic, 0)
```
It would be nice to use iteration thought all events in topic
```
func (t *MockTracker) Next(topic string) ([]byte, []byte) {
```
is used exactly for that

PS: + it fixes one bug in mock tracker
