### PR TITLE
Encode `nil` as empty message aka "tombstone" in BaseTrackerEncoding

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -30,7 +30,8 @@ ifeq ($(GOMETALINTER_EXCLUDES),)
 		--exclude "_test\.go:.*\((lll|unparam|gocyclo)\)$$" \
 		--exclude "comment should be of the form.*\(golint\)$$" \
 		--exclude "should have comment or be unexported.*\(golint\)$$" \
-		--exclude "Errors unhandled.,LOW,HIGH*\(gosec\)$$"
+		--exclude ".*Errors unhandled\.,LOW,HIGH \(gosec\)$$" \
+		--exclude ".*is a global variable \(gochecknoglobals\)$$"
 endif
 
 CODE_VERSION=$(TRAVIS_COMMIT)

--- a/Makefile.common
+++ b/Makefile.common
@@ -29,7 +29,8 @@ ifeq ($(GOMETALINTER_EXCLUDES),)
 		--exclude "_easyjson\.go:" \
 		--exclude "_test\.go:.*\((lll|unparam|gocyclo)\)$$" \
 		--exclude "comment should be of the form.*\(golint\)$$" \
-		--exclude "should have comment or be unexported.*\(golint\)$$"
+		--exclude "should have comment or be unexported.*\(golint\)$$" \
+		--exclude "Errors unhandled.,LOW,HIGH*\(gosec\)$$"
 endif
 
 CODE_VERSION=$(TRAVIS_COMMIT)

--- a/main/tracker.go
+++ b/main/tracker.go
@@ -7,7 +7,6 @@ import (
 )
 
 type testEvent struct {
-	tracker.EventBase
 	MyField string
 }
 

--- a/tracker.go
+++ b/tracker.go
@@ -34,6 +34,12 @@ type BaseTracker struct {
 // timestamp if `Timestampable`  and as json if implementing `json.Marshaler`. Falling back to `json.Marshal` otherwise
 // fields.
 func (t *BaseTracker) Encode(message interface{}) ([]byte, error) {
+	// nil fallback
+	if message == nil {
+		// message should not be nil, as a fallback, treat that as a "tombstone" empty message
+		return []byte{}, nil
+	}
+
 	// basic types
 	switch m := message.(type) {
 	case []byte:

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -63,6 +63,7 @@ func TestBaseTrackerEncoding(t *testing.T) {
 		{&testEventSimple{}, `{"Service":"Service","Environment":"Environment","Cluster":"Cluster","Host":"Host","Release":"Release"}`},
 		{&customJsonEvent{}, "test"},
 		{&timestampableEvent{}, `{"Now":"1982-04-03T12:00:00Z"}`},
+		{nil, ""},
 	} {
 		actual, err := tracker.Encode(e.given)
 		assert.NoError(t, err)

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -28,9 +28,9 @@ func (e *testEventSimple) SetMetadata(service, environment, cluster, host, relea
 	e.EventMetadata = &EventMetadata{service, environment, cluster, host, release}
 }
 
-type customJsonEvent struct{}
+type customJSONEvent struct{}
 
-func (*customJsonEvent) MarshalJSON() ([]byte, error) {
+func (*customJSONEvent) MarshalJSON() ([]byte, error) {
 	return []byte("test"), nil
 }
 
@@ -61,7 +61,7 @@ func TestBaseTrackerEncoding(t *testing.T) {
 		{map[string]interface{}{"hallo": "test"}, `{"hallo":"test","ts":"1982-04-03T12:00:00Z"}`},
 		{&testEvent{}, `{"Service":"Service","Environment":"Environment","Cluster":"Cluster","Host":"Host","Release":"Release"}`},
 		{&testEventSimple{}, `{"Service":"Service","Environment":"Environment","Cluster":"Cluster","Host":"Host","Release":"Release"}`},
-		{&customJsonEvent{}, "test"},
+		{&customJSONEvent{}, "test"},
 		{&timestampableEvent{}, `{"Now":"1982-04-03T12:00:00Z"}`},
 		{nil, ""},
 	} {


### PR DESCRIPTION
Removed obsolete `tracker.EventBase` reference from `main/tracker.go`