### PR TITLE
[3090] increase retries number and backoff for safe producer

### DIFF
--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/rcrowley/go-metrics"
@@ -101,6 +102,8 @@ func NewKafkaTrackerConfig(trackerConfig KafkaTrackerConfig) (t *KafkaTracker,
 		trackerConfig.Metadata.Service,
 	)
 
+	config.Producer.Retry.Max = 10
+	config.Producer.Retry.Backoff = 200 * time.Millisecond
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
 	config.Producer.RequiredAcks = sarama.WaitForLocal


### PR DESCRIPTION
[Trello card](https://trello.com/c/lygh5IkM/3090-investigate-temporary-kafka-produce-errors-act-trigger)

Let's try to increase both number of retries and backoff time and see if it will be enough to sustain kafka rebalancing.