### PR TITLE
Fix data race in MockTracker

### DIFF
--- a/mock_tracker.go
+++ b/mock_tracker.go
@@ -1,8 +1,11 @@
 package tracker
 
+import "sync"
+
 // MockTracker is a tracker with in-memory storage used for testing.
 type MockTracker struct {
 	BaseTracker
+	mapLock  sync.RWMutex
 	Messages map[string][][]byte
 	ids      map[string][][]byte
 }
@@ -39,6 +42,9 @@ func (t *MockTracker) Iterate(topic string) MockTopicIterator {
 
 // Get a message from the mock broker.
 func (t *MockTracker) Get(topic string, idx int) []byte {
+	t.mapLock.RLock()
+	defer t.mapLock.RUnlock()
+
 	if len(t.Messages) == 0 {
 		return nil
 	}
@@ -53,6 +59,9 @@ func (t *MockTracker) Get(topic string, idx int) []byte {
 
 // GetKey Gets a key from the mock broker.
 func (t *MockTracker) GetKey(topic string, idx int) []byte {
+	t.mapLock.RLock()
+	defer t.mapLock.RUnlock()
+
 	if len(t.Messages) == 0 {
 		return nil
 	}
@@ -70,6 +79,9 @@ func (t *MockTracker) Close() {
 }
 
 func (t *MockTracker) FastMessageWithKey(topic string, value interface{}, key []byte) error {
+	t.mapLock.Lock()
+	defer t.mapLock.Unlock()
+
 	valueBuf, err := t.Encode(value)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes the race seen here: https://circleci.com/gh/remerge/bidder/289
Or here: https://circleci.com/gh/remerge/bidder/444
```
==================
WARNING: DATA RACE
Read at 0x00c000a04db0 by goroutine 180:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/map_faststr.go:12 +0x0
  github.com/remerge/go-tracker.(*MockTracker).FastMessageWithKey()
      /go/pkg/mod/github.com/remerge/go-tracker@v0.0.0-20181221184943-fa24003c5f7d/mock_tracker.go:78 +0xf5
  github.com/remerge/go-tracker.(*MockTracker).FastMessage()
      /go/pkg/mod/github.com/remerge/go-tracker@v0.0.0-20181221184943-fa24003c5f7d/mock_tracker.go:89 +0x7e
  github.com/remerge/bidevent.TrackWithError()
      /go/pkg/mod/github.com/remerge/bidevent@v0.0.0-20190517143330-166b6d17c2fc/bid_event.go:202 +0xe8
  github.com/remerge/bidevent.Track()
      /go/pkg/mod/github.com/remerge/bidevent@v0.0.0-20190517143330-166b6d17c2fc/bid_event.go:189 +0x88
  github.com/remerge/bidder.(*Request).Track()
      /home/circleci/project/request.go:322 +0x234
  github.com/remerge/bidder.(*Request).ProcessFragment()
      /home/circleci/project/request.go:265 +0x41d
  github.com/remerge/bidder.(*serverHandler).Handle()
      /home/circleci/project/server.go:227 +0x1649
  github.com/remerge/bidder/internal/test.handleRequest()
      /home/circleci/project/internal/test/request_call.go:140 +0x836
  github.com/remerge/bidder/internal/test.SendOpenRTBRequest()
      /home/circleci/project/internal/test/request_call.go:65 +0x180
  github.com/remerge/bidder.TestServerHandlerCheckDisEnablingOfTargetingSwitch.func1.2()
      /home/circleci/project/server_test.go:964 +0x58b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Previous write at 0x00c000a04db0 by goroutine 165:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:190 +0x0
  github.com/remerge/go-tracker.(*MockTracker).FastMessageWithKey()
      /go/pkg/mod/github.com/remerge/go-tracker@v0.0.0-20181221184943-fa24003c5f7d/mock_tracker.go:78 +0x1f7
  github.com/remerge/go-tracker.(*MockTracker).FastMessage()
      /go/pkg/mod/github.com/remerge/go-tracker@v0.0.0-20181221184943-fa24003c5f7d/mock_tracker.go:89 +0x7e
  github.com/remerge/bidder/track.(*BidRequestTracker).Flush.func1()
      /home/circleci/project/track/request.go:43 +0xf8
  sync.(*Map).Range()
      /usr/local/go/src/sync/map.go:337 +0x13c
  github.com/remerge/bidder/track.(*BidRequestTracker).Flush()
      /home/circleci/project/track/request.go:37 +0xe3
  github.com/remerge/bidder/track.(*BidRequestTracker).Flush-fm()
      /home/circleci/project/server.go:60 +0x41
  github.com/remerge/bidder/track.(*Ticker).Run()
      /home/circleci/project/track/ticker.go:31 +0xaf
```

https://trello.com/c/2FMAnY1i/3706-fix-data-race-in-mocktracker