### PR TITLE
Add closed flag to kafka tracker

### DIFF
--- a/kafka_tracker.go
+++ b/kafka_tracker.go
@@ -125,7 +125,7 @@ func NewKafkaTrackerConfig(trackerConfig KafkaTrackerConfig) (t *KafkaTracker,
 	return t, nil
 }
 
-// producerErrorSummary returns summary over occured errors
+// producerErrorSummary returns summary over occurred errors
 func producerErrorSummary(errs sarama.ProducerErrors) error {
 	var es sync.Map
 


### PR DESCRIPTION
It looks like messages are being sent during the closing process. When the process of closing of the async producer is initiated (https://github.com/remerge/sarama/blob/731cdd3d4c5654062a84903948d00edc61a084e7/async_producer.go#L211), the sarama's input channel isn't closed yet, but the shutdown message was already sent (https://github.com/remerge/sarama/blob/731cdd3d4c5654062a84903948d00edc61a084e7/async_producer.go#L825). Perhaps, some messages are being sent just after the shutdown message, otherwise, it would be led to panic due to sending to the closed channel.
